### PR TITLE
✨ Implement pydantic type validation

### DIFF
--- a/examples/example_006_pydantic_types.py
+++ b/examples/example_006_pydantic_types.py
@@ -1,0 +1,15 @@
+import typer
+from pydantic.types import conint
+
+from pydantic_typer import enable_pydantic_type_validation
+
+EvenInt = conint(multiple_of=2)
+
+
+@enable_pydantic_type_validation
+def main(num: EvenInt):  # type: ignore
+    print(num, type(num))
+
+
+if __name__ == "__main__":
+    typer.run(main)

--- a/src/pydantic_typer/__init__.py
+++ b/src/pydantic_typer/__init__.py
@@ -1,3 +1,3 @@
-from pydantic_typer.main import PydanticTyper, enable_pydantic
+from pydantic_typer.main import PydanticTyper, enable_pydantic, enable_pydantic_type_validation
 
-__all__ = "PydanticTyper", "enable_pydantic"
+__all__ = "PydanticTyper", "enable_pydantic", "enable_pydantic_type_validation"


### PR DESCRIPTION
## 🚧 WIP

This PR re-implements pydantic type validation as originally implemented in the pydantic [PR](https://github.com/tiangolo/typer/pull/723) by @lachaib using [`pydantic.TypeAdapter`](https://docs.pydantic.dev/2.3/usage/type_adapter/). As a result, [custom types are also supported](https://github.com/tiangolo/typer/pull/723#issuecomment-2079523430).