### PR TITLE
DRAFT: Add wrap_with_model_yaml decorator

### DIFF
--- a/src/pydantic_typer/utils.py
+++ b/src/pydantic_typer/utils.py
@@ -44,6 +44,28 @@ def inspect_signature(func: Callable[..., Any]) -> inspect.Signature:  # pragma:
         signature = raw_signature.replace(parameters=resolved_params)
     return signature
 
+def _clear_empty_dictionaries(dictionary : dict) -> dict:
+    """A utility to recursively remove empty dictionaries
+    so they will not overwrite anything when used for updates.
+
+    Args:
+        dictionary : dict
+            The dictionary in question, which may have any heterogeneous contents
+
+    Returns:
+        The input dictionary with any empty dictionaries removed recursively
+    """
+    new_dict = {}
+    for key,val in dictionary.items():
+        if isinstance(val, dict):
+            new_val = _clear_empty_dictionaries(val)
+            if not new_val:
+                continue
+            else:
+                new_dict[key] = new_val
+        else:
+            new_dict[key] = val
+    return new_dict
 
 _T = TypeVar("_T")
 


### PR DESCRIPTION
Hi @pypae - thank you for making this very nice extension! I've been hoping for something exactly like this, and I will very likely be using it in the future.

For this PR, I am not sure if it's the sort of feature you are interested in, but I have written it for my own purposes anyways so figured I would share it in case you are. Basically, it adds a decorator to make a function accept yaml(s) which are parsed initially to build the model, then accepts updates from the standard command line arguments. This is analogous to the way that configargparse extends the basic argparse functionality (though, in my opinion, a lot cleaner). If you are interested in adding this, I can work on tests/documentation and make any changes you might suggest.

To do this it does introduce two new dependencies ([pydantic-yaml](https://pypi.org/project/pydantic-yaml/) and [makefun](https://smarie.github.io/python-makefun/)). 

An example usage would be:
```
from pydantic import BaseModel, Field
from typing import Optional
from pydantic_typer.main import wrap_with_model_yaml, run

class ExampleSubModel(BaseModel):
    user : Optional[str] = Field(default=None, description="The user")
    account_id : Optional[int] = Field(default=None, description="The id of the account")

class ExampleModel(BaseModel):
    user : Optional[str] = Field(default=None, description="The user")
    account_id : Optional[int] = Field(default=None, description="The id of the account")
    sub_model : ExampleSubModel 

class AnotherExampleModel(BaseModel):
    user : Optional[str] = Field(default=None, description="The user")
    account_id : Optional[int] = Field(default=None, description="The id of the account")

@wrap_with_model_yaml
def example_wrapped_config(model_1 : ExampleModel, model_2 : AnotherExampleModel, not_a_model_arg : int = 3, untyped_arg = "hi"):
    print(model_1)
    print(model_2)

if __name__ == "__main__":
    run(example_wrapped_config)
```

which yields this help message

```
$ (dev-gw-project-db) [rhiannonu@rhiannon-laptop Experiments]$ python test_pydantic_typer.py --help
                                                                                                                                                              
 Usage: test_pydantic_typer.py [OPTIONS] CONFIG_MODEL_1 CONFIG_MODEL_2                                                                                        
                                                                                                                                                              
╭─ Arguments ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ *    config_model_1      TEXT  [default: None] [required]                                                                                                  │
│ *    config_model_2      TEXT  [default: None] [required]                                                                                                  │
╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
╭─ Options ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ --not-a-model-arg                     INTEGER  [default: 3]                                                                                                │
│ --untyped-arg                         TEXT     [default: hi]                                                                                               │
│ --model_1.user                        TEXT     The user [default: None]                                                                                    │
│ --model_1.account_id                  INTEGER  The id of the account [default: None]                                                                       │
│ --model_1.sub_model.user              TEXT     The user [default: None]                                                                                    │
│ --model_1.sub_model.account_id        INTEGER  The id of the account [default: None]                                                                       │
│ --model_2.user                        TEXT     The user [default: None]                                                                                    │
│ --model_2.account_id                  INTEGER  The id of the account [default: None]                                                                       │
│ --help                                         Show this message and exit.                                                                                 │
╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
```
and produces an output like this:
```
$ (dev-gw-project-db) [rhiannonu@rhiannon-laptop Experiments]$ python test_pydantic_typer.py example_model_config.yaml another_example_model_config.yaml --model_1.user "custom user"

user='custom user' account_id=4 sub_model=ExampleSubModel(user='sub user', account_id=16)
user='another user' account_id=111
```
